### PR TITLE
Support shader array and some more registers in DX9 effect

### DIFF
--- a/src/DXDecompiler/DX9Shader/Bytecode/InstructionToken.cs
+++ b/src/DXDecompiler/DX9Shader/Bytecode/InstructionToken.cs
@@ -431,10 +431,13 @@ namespace DXDecompiler.DX9Shader
 		public string GetDeclSemantic()
 		{
 			var registerType = GetParamRegisterType(1);
+			var declIndexString = GetDeclIndex() == 0
+				? string.Empty
+				: GetDeclIndex().ToString();
 			switch(registerType)
 			{
 				case RegisterType.Input:
-				case RegisterType.Output:
+				case RegisterType.Output when _shaderModel.Type == ShaderType.Vertex && _shaderModel.MajorVersion >= 3:
 					string name;
 					switch(GetDeclUsage())
 					{
@@ -457,11 +460,7 @@ namespace DXDecompiler.DX9Shader
 						default:
 							throw new NotImplementedException();
 					}
-					if(GetDeclIndex() != 0)
-					{
-						name += GetDeclIndex().ToString();
-					}
-					return name;
+					return name + declIndexString;
 				case RegisterType.Sampler:
 					var samplerTexturetype = GetDeclSamplerTextureType();
 					switch(samplerTexturetype)
@@ -485,8 +484,11 @@ namespace DXDecompiler.DX9Shader
 						return "vPos";
 					}
 					throw new NotImplementedException();
-				case RegisterType.Addr:
-					return "tex";
+				case RegisterType.Texture when _shaderModel.Type == ShaderType.Pixel && _shaderModel.MajorVersion <= 2:
+					var registerNumber = GetParamRegisterNumber(1);
+					return "TEXCOORD" + (registerNumber == 0 ? string.Empty : registerNumber.ToString());
+				case RegisterType.TexCoordOut:
+					return "TEXCOORD" + declIndexString;
 				default:
 					//return "Warning - Not Implemented register type";
 					throw new NotImplementedException();

--- a/src/DXDecompiler/DX9Shader/Bytecode/InstructionToken.cs
+++ b/src/DXDecompiler/DX9Shader/Bytecode/InstructionToken.cs
@@ -300,7 +300,7 @@ namespace DXDecompiler.DX9Shader
 					return i + 1;
 				}
 			}
-			return 0;
+			return 1; // I think it can't be zero...
 		}
 
 		// Length of ".yw" = 2

--- a/src/DXDecompiler/DX9Shader/Bytecode/RegisterType.cs
+++ b/src/DXDecompiler/DX9Shader/Bytecode/RegisterType.cs
@@ -13,7 +13,8 @@
 		Addr = Texture,
 		RastOut,
 		AttrOut,
-		Output,
+		TexCoordOut, // used in vs_2_0 and below
+		Output = TexCoordOut,
 		ConstInt,
 		ColorOut,
 		DepthOut,

--- a/src/DXDecompiler/DX9Shader/Decompiler/HlslWriter.cs
+++ b/src/DXDecompiler/DX9Shader/Decompiler/HlslWriter.cs
@@ -355,6 +355,7 @@ namespace DXDecompiler.DX9Shader
 						break;
 						//throw new NotImplementedException();
 				}
+				WriteIndent();
 				WriteLine("{0} {1};", writeMaskName, string.Join(", ", group));
 			}
 
@@ -406,6 +407,7 @@ namespace DXDecompiler.DX9Shader
 			else
 			{
 				var output = _registers.MethodOutputRegisters.First().Value;
+				WriteIndent();
 				WriteLine("{0} {1};", methodReturnType, _registers.GetRegisterName(output.RegisterKey));
 			}
 			WriteTemps();
@@ -424,11 +426,13 @@ namespace DXDecompiler.DX9Shader
 
 				if(_registers.MethodOutputRegisters.Count > 1)
 				{
+					WriteIndent();
 					WriteLine($"return o;");
 				}
 				else
 				{
 					var output = _registers.MethodOutputRegisters.First().Value;
+					WriteIndent();
 					WriteLine($"return {_registers.GetRegisterName(output.RegisterKey)};");
 				}
 
@@ -493,6 +497,7 @@ namespace DXDecompiler.DX9Shader
 			Indent++;
 			foreach(var input in _registers.MethodInputRegisters.Values)
 			{
+				WriteIndent();
 				WriteLine($"{input.TypeName} {input.Name} : {input.Semantic};");
 			}
 			Indent--;
@@ -508,7 +513,9 @@ namespace DXDecompiler.DX9Shader
 			Indent++;
 			foreach(var output in _registers.MethodOutputRegisters.Values)
 			{
+				WriteIndent();
 				WriteLine($"// {output.RegisterKey} {Operand.GetParamRegisterName(output.RegisterKey.Type, (uint)output.RegisterKey.Number)}");
+				WriteIndent();
 				WriteLine($"{output.TypeName} {output.Name} : {output.Semantic};");
 			}
 			Indent--;
@@ -613,9 +620,8 @@ namespace DXDecompiler.DX9Shader
 			{
 				WriteLine(shader.Prsi.Dump());
 			}
-			Indent++;
+			Indent--;
 			WriteLine("}");
-
 		}
 	}
 }

--- a/src/DXDecompiler/DX9Shader/Decompiler/HlslWriter.cs
+++ b/src/DXDecompiler/DX9Shader/Decompiler/HlslWriter.cs
@@ -10,6 +10,7 @@ namespace DXDecompiler.DX9Shader
 	{
 		private readonly ShaderModel _shader;
 		private readonly bool _doAstAnalysis;
+		private int _iterationDepth = 0;
 
 		public RegisterState _registers;
 		string _entryPoint;
@@ -87,6 +88,32 @@ namespace DXDecompiler.DX9Shader
 		{
 			WriteIndent();
 			WriteLine($"// {instruction}");
+			switch(instruction.Opcode)
+			{
+				case Opcode.Def:
+				case Opcode.DefI:
+				case Opcode.Dcl:
+				case Opcode.End:
+					return;
+				// these opcodes doesn't need indents:
+				case Opcode.Else:
+					Indent--;
+					WriteIndent();
+					WriteLine("} else {");
+					Indent++;
+					return;
+				case Opcode.Endif:
+					Indent--;
+					WriteIndent();
+					WriteLine("}");
+					return;
+				case Opcode.EndRep:
+					Indent--;
+					_iterationDepth--;
+					WriteIndent();
+					WriteLine("}");
+					return;
+			}
 			WriteIndent();
 			switch(instruction.Opcode)
 			{
@@ -114,15 +141,6 @@ namespace DXDecompiler.DX9Shader
 				case Opcode.Dp4:
 					WriteLine("{0} = dot({1}, {2});", GetDestinationName(instruction),
 						GetSourceName(instruction, 1), GetSourceName(instruction, 2));
-					break;
-				case Opcode.Else:
-					Indent--;
-					WriteLine("} else {");
-					Indent++;
-					break;
-				case Opcode.Endif:
-					Indent--;
-					WriteLine("}");
 					break;
 				case Opcode.Exp:
 					WriteLine("{0} = exp2({1});", GetDestinationName(instruction), GetSourceName(instruction, 1));
@@ -272,8 +290,16 @@ namespace DXDecompiler.DX9Shader
 						WriteLine($"// Comment: {ascii}");
 						break;
 					}
-				case Opcode.End:
+				case Opcode.Rep:
+					WriteLine("for (int it{0} = 0; it{0} < {1}; ++it{0}) {{", _iterationDepth, GetSourceName(instruction, 0));
+					_iterationDepth++;
+					Indent++;
 					break;
+				case Opcode.TexKill:
+					WriteLine("clip({0});", GetDestinationName(instruction));
+					break;
+				default:
+					throw new NotImplementedException(instruction.Opcode.ToString());
 			}
 		}
 		void WriteTemps()


### PR DESCRIPTION
There are some registers with the same id, but are actually different types between different shader models, which should be properly handled with this pull request.
This pull request will also support shader array in `EffectHlslWriter.cs` and few more opcodes in `HlslWriter.cs`