### PR TITLE
Improved handling of DX9 constant declarations

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -4,6 +4,7 @@ root = true
 # Cs files
 [*.cs]
 indent_style = tab
+indent_size = 4
 csharp_space_after_cast = false
 csharp_space_after_keywords_in_control_flow_statements = false
 csharp_space_before_colon_in_inheritance_clause = true

--- a/src/DXDecompiler.Tests/DXDecompiler.Tests.csproj
+++ b/src/DXDecompiler.Tests/DXDecompiler.Tests.csproj
@@ -79,6 +79,7 @@
     <Compile Include="AssertTraceListener.cs" />
     <Compile Include="ShaderCompiler.cs" />
     <Compile Include="DX10Util\Extension.cs" />
+    <Compile Include="TestFixtures\TestDX9Effects.cs" />
     <Compile Include="TestFixtures\CompileShadersFixture.cs" />
     <Compile Include="TestFixtures\DX9Tests.cs" />
     <Content Include="FXC\D3DCompiler_43.dll">

--- a/src/DXDecompiler.Tests/TestFixtures/TestDX9Effects.cs
+++ b/src/DXDecompiler.Tests/TestFixtures/TestDX9Effects.cs
@@ -119,9 +119,11 @@ namespace DXDecompiler.Tests
 				U u[3];
 
 				float4 HakureiReimuAliceMargatroid;
+				row_major float2x2 m;
+				column_major float2x2 n;
 
 				float4 VS(float4 p : POSITION) : POSITION {
-					return p * HakureiReimuAliceMargatroid.w * u[2].t[1].v;
+					return p * HakureiReimuAliceMargatroid.w  * u[2].t[1].v * m[0].y * n[0].y;
 				}
 
 				technique Tq {
@@ -144,6 +146,10 @@ namespace DXDecompiler.Tests
 			StringAssert.Contains("HakureiReimuAliceMargatroid.w", decompiled);
 			// assert that `u[2].t[1].v` appears inside the decompiled source code
 			StringAssert.Contains("u[2].t[1].v", decompiled);
+
+			var fromNonAst = HlslWriter.Decompile(bytecode);
+			StringAssert.Contains("HakureiReimuAliceMargatroid.w", fromNonAst);
+			StringAssert.Contains("u[2].t[1].v", fromNonAst);
 		}
 	}
 }

--- a/src/DXDecompiler.Tests/TestFixtures/TestDX9Effects.cs
+++ b/src/DXDecompiler.Tests/TestFixtures/TestDX9Effects.cs
@@ -1,0 +1,149 @@
+﻿using DXDecompiler.DX9Shader;
+using NUnit.Framework;
+using SharpDX.D3DCompiler;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DXDecompiler.Tests
+{
+	[TestFixture]
+	class TestDX9Effects
+	{
+		// TODO: double is not supported yet.
+		[Test]
+		public void TestEffect9Constants()
+		{
+			var bytecode = ShaderBytecode.Compile(@"
+				struct T {
+					float f;
+					int i;
+					int2 j;
+					float4 v;
+				};
+				T t : register(vs, c5) : register(ps, c5) = {
+					1.0f,
+					2,
+					int2(2, 3),
+					float4(4, 5, 6, 7)
+				};
+
+				struct M {
+					column_major float2x3 f;
+					float g;
+				} m : register(vs, c80) : register(ps, c80);
+
+				struct U {
+					row_major float2x3 f;
+					T t[2];
+					float g;
+				};
+				U u[3] : register(vs, c10) : register(ps, c10);
+
+				float4 VS(float4 p : POSITION) : POSITION {
+					// some random code which uses those constants
+					// so they won't be optimized away.
+					return p * 2 * t.i * u[2].g * m.g * u[0].t[1].v;
+				}
+
+				technique Tq {
+					pass p0 {
+						VertexShader = compile vs_2_0 VS();
+					}
+				}
+			", "fx_2_0").Bytecode;
+			var shaderModel = ShaderReader.ReadShader(bytecode);
+			var constants = from blob in shaderModel.EffectChunk.StateBlobLookup.Values
+							where blob.BlobType == DX9Shader.FX9.StateBlobType.Shader
+							from constdecl in blob.Shader.ConstantTable.ConstantDeclarations
+							select constdecl;
+			// constant "t"
+			var t = constants.First(c => c.Name == "t");
+			Assert.AreEqual(5, t.RegisterIndex);
+
+			var t_j = t.GetRegisterTypeByOffset(2);
+			Assert.AreEqual(7, t_j.RegisterIndex);
+			Assert.AreEqual(ParameterClass.Vector, t_j.Type.ParameterClass);
+			Assert.AreEqual(ParameterType.Int, t_j.Type.ParameterType);
+			var int2Name = t.GetMemberNameByOffset(2);
+			Assert.AreEqual("t.j", int2Name);
+
+			// constant "m"
+			var m = constants.First(c => c.Name == "m");
+			Assert.AreEqual(80, m.RegisterIndex);
+
+			var m_f = m.GetRegisterTypeByOffset(2);
+			Assert.AreEqual(80, m_f.RegisterIndex);
+			Assert.AreEqual(ParameterClass.MatrixColumns, m_f.Type.ParameterClass);
+			Assert.AreEqual("m.f", m.GetMemberNameByOffset(2));
+
+			var m_g = m.GetRegisterTypeByOffset(3);
+			Assert.AreEqual(83, m_g.RegisterIndex);
+			Assert.AreEqual("m.g", m.GetMemberNameByOffset(3));
+
+			// constant "u"
+			var u = constants.First(c => c.Name == "u");
+			Assert.AreEqual(10, u.RegisterIndex);
+
+			var u_2_g = u.GetRegisterTypeByOffset(32);
+			Assert.AreEqual(42, u_2_g.RegisterIndex);
+			Assert.AreEqual(ParameterClass.Scalar, u_2_g.Type.ParameterClass);
+			Assert.AreEqual("u[2].g", u.GetMemberNameByOffset(32));
+
+			var u_2_t_1_v = u.GetRegisterTypeByOffset(31);
+			Assert.AreEqual(41, u_2_t_1_v.RegisterIndex);
+			Assert.AreEqual(ParameterClass.Vector, u_2_t_1_v.Type.ParameterClass);
+			Assert.AreEqual(ParameterType.Float, u_2_t_1_v.Type.ParameterType);
+			Assert.AreEqual(1, u_2_t_1_v.Type.Rows);
+			Assert.AreEqual(4, u_2_t_1_v.Type.Columns);
+			Assert.AreEqual("u[2].t[1].v", u.GetMemberNameByOffset(31));
+		}
+
+		// TODO: double is not supported yet.
+		[Test]
+		public void TestSimpleVertexShaderWithConstants()
+		{
+			var bytecode = ShaderBytecode.Compile(@"
+				struct T {
+					float f;
+					float4 v;
+				};
+
+				struct U {
+					row_major float2x3 f;
+					T t[2];
+					float g;
+				};
+				U u[3];
+
+				float4 HakureiReimuAliceMargatroid;
+
+				float4 VS(float4 p : POSITION) : POSITION {
+					return p * HakureiReimuAliceMargatroid.w * u[2].t[1].v;
+				}
+
+				technique Tq {
+					pass p0 {
+						VertexShader = compile vs_3_0 VS();
+					}
+				}
+			", "fx_2_0").Bytecode;
+			var shaderModel = ShaderReader.ReadShader(bytecode);
+			var vertexShaders = from blob in shaderModel.EffectChunk.StateBlobLookup.Values
+								where blob.BlobType == DX9Shader.FX9.StateBlobType.Shader
+								where blob.Shader.Type == ShaderType.Vertex
+								select blob.Shader;
+			var testVertexShader = vertexShaders.First();
+			var hlslWriter = new HlslWriter(testVertexShader, doAstAnalysis: true);
+			var decompiled = hlslWriter.Decompile();
+			// here we use the `.w` component, to make sure `HakureiReimuAliceMargatroid.w` 
+			// is inside the actual decompiled shader too, not just inside constant declaration 
+			// (that is, `float4 HakureiReimuAliceMargatroid`).
+			StringAssert.Contains("HakureiReimuAliceMargatroid.w", decompiled);
+			// assert that `u[2].t[1].v` appears inside the decompiled source code
+			StringAssert.Contains("u[2].t[1].v", decompiled);
+		}
+	}
+}

--- a/src/DXDecompiler/DX9Shader/Bytecode/Declaration/ConstantDeclaration.cs
+++ b/src/DXDecompiler/DX9Shader/Bytecode/Declaration/ConstantDeclaration.cs
@@ -228,14 +228,26 @@ namespace DXDecompiler.DX9Shader.Bytecode.Declaration
 							}
 						}
 						continue;
-					case ParameterClass.MatrixColumns:
-					case ParameterClass.MatrixRows:
-					case ParameterClass.Scalar:
-					case ParameterClass.Vector:
+					case ParameterClass.Object:
 						// sanity check
 						if(type.Members.Any())
 						{
-							throw new NotImplementedException();
+							throw new InvalidOperationException();
+						}
+						if(remainedOffset == 0)
+						{
+							return true;
+						}
+						remainedOffset -= 1;
+						continue;
+					case ParameterClass.MatrixColumns:
+					case ParameterClass.MatrixRows:
+					case ParameterClass.Vector:
+					case ParameterClass.Scalar:
+						// sanity check
+						if(type.Members.Any())
+						{
+							throw new InvalidOperationException();
 						}
 						registersOccupied = type.ParameterClass == ParameterClass.MatrixColumns
 							? type.Columns
@@ -245,6 +257,9 @@ namespace DXDecompiler.DX9Shader.Bytecode.Declaration
 						throw new NotImplementedException();
 				}
 
+				// ParameterClass.MatrixColumns / ParameterClass.Rows
+				// ParameterClass.Vector
+				// ParameterClass.Scalar:
 				switch(type.ParameterType)
 				{
 					case ParameterType.Bool:

--- a/src/DXDecompiler/DX9Shader/Bytecode/Declaration/ConstantDeclaration.cs
+++ b/src/DXDecompiler/DX9Shader/Bytecode/Declaration/ConstantDeclaration.cs
@@ -1,5 +1,7 @@
 ﻿using DXDecompiler.Util;
+using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace DXDecompiler.DX9Shader.Bytecode.Declaration
 {
@@ -68,7 +70,6 @@ namespace DXDecompiler.DX9Shader.Bytecode.Declaration
 			}
 			return result;
 		}
-
 		public bool ContainsIndex(uint index)
 		{
 			return (index >= RegisterIndex) && (index < RegisterIndex + RegisterCount);
@@ -85,6 +86,184 @@ namespace DXDecompiler.DX9Shader.Bytecode.Declaration
 		public string GetRegisterName()
 		{
 			return $"{RegisterSet.GetDescription()}{RegisterIndex}";
+		}
+
+		public class ConstantRegisterData
+		{
+			public ConstantType Type { get; }
+			public uint RegisterIndex { get; }
+
+			public ConstantRegisterData(ConstantType type, uint registerIndex)
+			{
+				Type = type;
+				RegisterIndex = registerIndex;
+			}
+		}
+		/// <summary>
+		/// Get the information of register by an offset, 
+		/// relative to the register index of this const declaration.
+		/// </summary>
+		/// <param name="offset">The offset, relative to this const declaration's initial address.</param>
+		/// <returns>Information about the specified register.</returns>
+		public ConstantRegisterData GetRegisterTypeByOffset(uint offset)
+		{
+			if(offset > RegisterCount)
+			{
+				throw new ArgumentOutOfRangeException();
+			}
+
+			var originalOffset = offset;
+			// keep track of the last visited type, which is the type of member being found
+			ConstantType lastType = null;
+			TraverseChildTree(ref offset, (type, name, i, d) =>
+			{
+				lastType = type;
+			});
+
+			// sanity check
+			if(lastType == null)
+			{
+				throw new InvalidOperationException();
+			}
+
+			// the offset of member, relative to the constant declaration's initial address
+			var memberOffset = originalOffset - offset;
+
+			return new ConstantRegisterData(lastType, RegisterIndex + memberOffset);
+		}
+
+		/// <summary>
+		/// Get the name of member variable by offset, 
+		/// relative to the register index of this const declaration.
+		/// </summary>
+		/// <param name="offset">The offset, relative to this const declaration's initial address.</param>
+		/// <returns>The member variable name.</returns>
+		public string GetMemberNameByOffset(uint offset)
+		{
+			if(offset > RegisterCount)
+			{
+				throw new ArgumentOutOfRangeException();
+			}
+			var indexes = new List<(string Name, uint Index, uint MaxIndex)> { (Name, 0, 0) };
+			var lastDepth = 0;
+			TraverseChildTree(ref offset, (type, name, index, depth) =>
+			{
+				if(depth >= indexes.Count)
+				{
+					indexes.Add((name, index, type.Elements));
+				}
+				else
+				{
+					indexes[depth] = (name, index, type.Elements);
+				}
+				lastDepth = depth;
+			});
+			// build the string
+			var result = string.Empty;
+			foreach(var (name, i, max) in indexes.Take(lastDepth + 1))
+			{
+				if(max > 1)
+				{
+					// we are accessing array elements
+					result += $"{name}[{i}].";
+				}
+				else
+				{
+					result += $"{name}.";
+				}
+			}
+			return result.TrimEnd('.');
+		}
+
+		private delegate void ChildTreeVisitor(ConstantType type, string name, uint index, int depth);
+
+		/// <summary>
+		/// Traverse the child tree of target variable, until a child matching the specified 
+		/// register offset has been found.
+		/// This might be useful when the target is a struct or an array.
+		/// </summary>
+		/// <param name="type">The type of current target.</param>
+		/// <param name="offset">
+		/// The offset of child element to be searched.
+		/// It will become 0 if a child element has been found exactly on the specified offset,
+		/// non-zero if we are accessing "in the middle of an element",
+		/// something like "accessing the 2nd column of matrix".
+		/// </param>
+		/// <param name="visitor">
+		/// The visitor will be called with child element type and current depth.
+		/// </param>
+		private void TraverseChildTree(ref uint offset, ChildTreeVisitor visitor)
+		{
+			var found = TraverseChildTree(Name, Type, ref offset, visitor, 0);
+			if(!found)
+			{
+				throw new InvalidOperationException();
+			}
+		}
+		private static bool TraverseChildTree(
+			string name,
+			ConstantType type,
+			ref uint remainedOffset,
+			ChildTreeVisitor visitor,
+			int depth)
+		{
+			for(var i = 0u; i < type.Elements; i++)
+			{
+				visitor(type, name, i, depth);
+
+				uint registersOccupied;
+				switch(type.ParameterClass)
+				{
+					case ParameterClass.Struct:
+						if(!type.Members.Any())
+						{
+							throw new NotImplementedException();
+						}
+						foreach(var member in type.Members)
+						{
+							var found = TraverseChildTree(member.Name, member.Type, ref remainedOffset, visitor, depth + 1);
+							if(found)
+							{
+								return true;
+							}
+						}
+						continue;
+					case ParameterClass.MatrixColumns:
+					case ParameterClass.MatrixRows:
+					case ParameterClass.Scalar:
+					case ParameterClass.Vector:
+						// sanity check
+						if(type.Members.Any())
+						{
+							throw new NotImplementedException();
+						}
+						registersOccupied = type.ParameterClass == ParameterClass.MatrixColumns
+							? type.Columns
+							: type.Rows;
+						break;
+					default:
+						throw new NotImplementedException();
+				}
+
+				switch(type.ParameterType)
+				{
+					case ParameterType.Bool:
+					case ParameterType.Float:
+					case ParameterType.Int:
+						// double is not supported for now as it occupies more than 1 register
+						// but it's not inside ParameterType?
+						break;
+					default:
+						throw new NotImplementedException();
+				}
+				if(remainedOffset < registersOccupied)
+				{
+					return true;
+					// here, remainedOffset intentionally left unchanged when returning true.
+				}
+				remainedOffset -= registersOccupied;
+			}
+			return false;
 		}
 	}
 }

--- a/src/DXDecompiler/DX9Shader/Decompiler/BytecodeParser.cs
+++ b/src/DXDecompiler/DX9Shader/Decompiler/BytecodeParser.cs
@@ -90,7 +90,8 @@ namespace DXDecompiler.DX9Shader
 				{
 					for(uint r = 0; r < constant.RegisterCount; r++)
 					{
-						if(constant.ParameterType != ParameterType.Float)
+						var data = constant.GetRegisterTypeByOffset(r);
+						if(data.Type.ParameterType != ParameterType.Float)
 						{
 							throw new NotImplementedException();
 						}

--- a/src/DXDecompiler/DX9Shader/Decompiler/RegisterState.cs
+++ b/src/DXDecompiler/DX9Shader/Decompiler/RegisterState.cs
@@ -221,8 +221,17 @@ namespace DXDecompiler.DX9Shader
 		{
 			if(registerKey.Type == RegisterType.Const)
 			{
-				var constant = FindConstant(ParameterType.Float, registerKey.Number);
-				return constant.Columns;
+				var constant = FindConstant(registerKey.Number);
+				var data = constant.GetRegisterTypeByOffset(registerKey.Number - constant.RegisterIndex);
+				if(data.Type.ParameterType != ParameterType.Float)
+				{
+					throw new NotImplementedException();
+				}
+				if(data.Type.ParameterClass == ParameterClass.MatrixColumns)
+				{
+					return data.Type.Rows;
+				}
+				return data.Type.Columns;
 			}
 
 			RegisterDeclaration decl = _registerDeclarations[registerKey];
@@ -255,22 +264,34 @@ namespace DXDecompiler.DX9Shader
 				case RegisterType.ColorOut:
 					return (MethodOutputRegisters.Count == 1) ? decl.Name : ("o." + decl.Name);
 				case RegisterType.Const:
-					var constDecl = FindConstant(ParameterType.Float, registerKey.Number);
-					if(ColumnMajorOrder)
+					var constDecl = FindConstant(/*ParameterType.Float, */ registerKey.Number);
+					var relativeOffset = registerKey.Number - constDecl.RegisterIndex;
+					var name = constDecl.GetMemberNameByOffset(relativeOffset);
+					var data = constDecl.GetRegisterTypeByOffset(relativeOffset);
+
+					// sanity check
+					var registersOccupied = data.Type.ParameterClass == ParameterClass.MatrixColumns
+						? data.Type.Columns
+						: data.Type.Rows;
+					if(registersOccupied == 1 && data.RegisterIndex != registerKey.Number)
 					{
-						if(constDecl.Rows == 1)
-						{
-							return constDecl.Name;
-						}
-						string col = (registerKey.Number - constDecl.RegisterIndex).ToString();
-						return $"transpose({constDecl.Name})[{col}]";
+						throw new InvalidOperationException();
 					}
-					if(constDecl.Rows == 1)
+
+					switch(data.Type.ParameterType)
 					{
-						return constDecl.Name;
+						case ParameterType.Float:
+							if(registersOccupied == 1)
+							{
+								return name;
+							}
+							var subElement = (registerKey.Number - data.RegisterIndex).ToString();
+							return ColumnMajorOrder
+								? $"transpose({name})[{subElement}]" // subElement = col
+								: $"{name}[{subElement}]"; // subElement = row;
+						default:
+							throw new NotImplementedException();
 					}
-					string row = (registerKey.Number - constDecl.RegisterIndex).ToString();
-					return constDecl.Name + $"[{row}]";
 				case RegisterType.Sampler:
 					ConstantDeclaration samplerDecl = FindConstant(RegisterSet.Sampler, registerKey.Number);
 					if(samplerDecl != null)

--- a/src/DXDecompiler/DX9Shader/Decompiler/RegisterState.cs
+++ b/src/DXDecompiler/DX9Shader/Decompiler/RegisterState.cs
@@ -188,7 +188,7 @@ namespace DXDecompiler.DX9Shader
 							throw new NotImplementedException();
 					}
 					var registerNumber = instruction.GetParamRegisterNumber(srcIndex);
-					ConstantDeclaration decl = FindConstant(parameterType, registerNumber);
+					ConstantDeclaration decl = FindConstant(registerNumber);
 					if(decl == null)
 					{
 						// Constant register not found in def statements nor the constant table
@@ -196,14 +196,17 @@ namespace DXDecompiler.DX9Shader
 						return $"Error {registerType}{registerNumber}";
 						//throw new NotImplementedException();
 					}
-
-					if(decl.ParameterClass == ParameterClass.MatrixRows)
+					var totalOffset = registerNumber - decl.RegisterIndex;
+					var data = decl.GetRegisterTypeByOffset(totalOffset);
+					var offsetFromMember = registerNumber - data.RegisterIndex;
+					sourceRegisterName = decl.GetMemberNameByOffset(totalOffset);
+					if(data.Type.ParameterClass == ParameterClass.MatrixRows)
 					{
-						sourceRegisterName = string.Format("{0}[{1}]", decl.Name, registerNumber - decl.RegisterIndex);
+						sourceRegisterName = string.Format("{0}[{1}]", decl.Name, offsetFromMember);
 					}
-					else
+					else if(data.Type.ParameterClass == ParameterClass.MatrixColumns)
 					{
-						sourceRegisterName = decl.Name;
+						sourceRegisterName = string.Format("transpose({0})[{1}]", decl.Name, offsetFromMember);
 					}
 					break;
 				default:

--- a/src/DXDecompiler/DX9Shader/Decompiler/RegisterState.cs
+++ b/src/DXDecompiler/DX9Shader/Decompiler/RegisterState.cs
@@ -267,7 +267,7 @@ namespace DXDecompiler.DX9Shader
 				case RegisterType.ColorOut:
 					return (MethodOutputRegisters.Count == 1) ? decl.Name : ("o." + decl.Name);
 				case RegisterType.Const:
-					var constDecl = FindConstant(/*ParameterType.Float, */ registerKey.Number);
+					var constDecl = FindConstant(registerKey.Number);
 					var relativeOffset = registerKey.Number - constDecl.RegisterIndex;
 					var name = constDecl.GetMemberNameByOffset(relativeOffset);
 					var data = constDecl.GetRegisterTypeByOffset(relativeOffset);
@@ -299,7 +299,8 @@ namespace DXDecompiler.DX9Shader
 					ConstantDeclaration samplerDecl = FindConstant(RegisterSet.Sampler, registerKey.Number);
 					if(samplerDecl != null)
 					{
-						return samplerDecl.Name;
+						var offset = registerKey.Number - samplerDecl.RegisterIndex;
+						return samplerDecl.GetMemberNameByOffset(offset);
 					}
 					else
 					{


### PR DESCRIPTION
Added two methods in `DXDecompiler.DX9Shader.Bytecode.Declaration`'s `ConstantDeclaration` 
(`GetRegisterTypeByOffset()` and `GetMemberNameByOffset()`) 
which allow us to get register information and member variable name from a DX9 constant declaration, by using an offset.

It can be used figure out the member variable type, 
or the register full length (`DXDecompiler.DX9Shader`'s `RegisterState.GetRegisterFullLength()`), 
or the member variable name (`RegisterState.GetRegisterName()`).

[DXDecompiler.Tests/TestFixtures/TestDX9Effects.cs ](https://github.com/lanyizi/DXDecompiler/blob/eae2b43623df52907fed2797934c7a0a83013304/src/DXDecompiler.Tests/TestFixtures/TestDX9Effects.cs) contains some sample code on how they can be used.

Example (took from test case): it's now able to figure out that the constant register `c19` is actually `u[2].t[1].v`
```hlsl
float4 HakureiReimuAliceMargatroid;

struct
{
    row_major float2x3 f;
    struct
{
        float f;
        float4 v;
    } t[2];
    float g;
} u[3];

float4 VertexMain(float4 position : POSITION) : POSITION
{
    float4 position;
    float4 temp0;
return HakureiReimuAliceMargatroid.wwww * position * u[2].t[1].v;
}
```

PS: I've added a tab size = 4 in `.editorconfig`, because it's used by Github too, so Github can correctly display tabs with width of 4 spaces. 
I'm not sure if that's your preference, if you prefer something like 8 or 2 as tab size, just tell me (or you can just change it yourself 😄)