### PR TITLE
Fixed DX9 disassembly's issues with relative addressing mode

### DIFF
--- a/src/DXDecompiler/DX9Shader/Asm/AsmWriter.cs
+++ b/src/DXDecompiler/DX9Shader/Asm/AsmWriter.cs
@@ -90,6 +90,10 @@ namespace DXDecompiler.DX9Shader
 			{
 				// compute the actual data index, which might be different from logical index 
 				// because of relative addressing mode.
+				
+				// TODO: Handle relative addressing mode in a better way,
+				// by using `InstructionToken.Operands`:
+				// https://github.com/spacehamster/DXDecompiler/pull/6#issuecomment-782958769
 
 				// if instruction has destination, then source starts at the index 1
 				// here we assume destination won't have relative addressing,

--- a/src/DXDecompiler/DX9Shader/Bytecode/InstructionToken.cs
+++ b/src/DXDecompiler/DX9Shader/Bytecode/InstructionToken.cs
@@ -51,6 +51,9 @@ namespace DXDecompiler.DX9Shader
 					result += GetSourceName(i);
 					if(IsRelativeAddressMode(i))
 					{
+						// TODO: Handle relative addressing mode in a better way,
+						// by using `InstructionToken.Operands`:
+						// https://github.com/spacehamster/DXDecompiler/pull/6#issuecomment-782958769
 						i++;
 					}
 				}

--- a/src/DXDecompiler/DX9Shader/Bytecode/InstructionToken.cs
+++ b/src/DXDecompiler/DX9Shader/Bytecode/InstructionToken.cs
@@ -49,6 +49,10 @@ namespace DXDecompiler.DX9Shader
 				else
 				{
 					result += GetSourceName(i);
+					if(IsRelativeAddressMode(i))
+					{
+						i++;
+					}
 				}
 			}
 			return result;
@@ -95,11 +99,11 @@ namespace DXDecompiler.DX9Shader
 			var instruction = this;
 			string sourceRegisterName = instruction.GetParamRegisterName(srcIndex);
 			sourceRegisterName = ApplyModifier(instruction.GetSourceModifier(srcIndex), sourceRegisterName);
-			sourceRegisterName += instruction.GetSourceSwizzleName(srcIndex);
 			if(instruction.IsRelativeAddressMode(srcIndex))
 			{
 				sourceRegisterName += $"[{GetSourceName(srcIndex + 1)}]";
 			}
+			sourceRegisterName += instruction.GetSourceSwizzleName(srcIndex);
 			return sourceRegisterName;
 		}
 


### PR DESCRIPTION
Fixed some unit test cases in `DX9Tests.AsmMatchesFxc`, which contain codes that use relative addressing, such as
`ShadersDX9/Sdk/Direct3D/IrradianceVolume/PRT.fx`.

More specifically, 
fixed erroneous disassemblies like `mad r6.x, c10.z[aL], aL, r6.z`
to the correct ones: `mad r6.x, c10[aL].z, r6.z, c10[aL].y`.